### PR TITLE
Stop gliding when player hits the ground

### DIFF
--- a/src/JavierLeon9966/VanillaElytra/VanillaElytra.php
+++ b/src/JavierLeon9966/VanillaElytra/VanillaElytra.php
@@ -81,6 +81,9 @@ final class VanillaElytra extends PluginBase implements Listener{
 			return;
 		}
 
+		if($player->isOnGround()){
+			$player->toggleGlide(false);
+		}
 		$location = $event->getFrom();
 		if($location->pitch >= self::MINIMUM_PITCH and $location->pitch <= self::MAXIMUM_PITCH){
 			$player->resetFallDistance();


### PR DESCRIPTION
this is workaround for #9 

1.20.10 doesn't seem to send the STOP_GLIDE flag when the player is on the ground